### PR TITLE
feat: datachannel parsing

### DIFF
--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -472,6 +472,36 @@ var grammar = module.exports = {
       names: ['id', 'mStream'],
       format: 'floorid:%s mstrm:%s'
     },
+    // RFC8864
+    {
+      // a=dcmap:2 subprotocol="msrp";ordered=true;label="msrp"
+      push: 'dcmaps',
+      reg: /^dcmap:(\d{1,5})(?: (.+))?/,
+      names: ['id', 'options'],
+      format: function (o) {
+        return (o.options) ? 'dcmap:%d %s' : 'dcmap:%d';
+      }
+    },
+    {
+      // a=dcsa:2 sendrecv
+      push: 'dcdirs',
+      reg: /^dcsa:(\d{1,5}) (sendrecv|recvonly|sendonly|inactive)/,
+      names: ['id', 'direction'],
+      format: 'dcsa:%d %s'
+    },
+    {
+      // a=dcsa:2 accept-types:text/plain
+      push: 'dcsas',
+      reg: /^dcsa:(\d{1,5}) ([\w!#$%&'*+\-.^`{|}~]+)(?::(.*))?/,
+      names: ['id', 'attribute', 'value'],
+      format: function (o) {
+        var str = 'dcsa:%d %s';
+        if (o.value != null) {
+          str += ':%s';
+        }
+        return str;
+      }
+    },
     {
       // any a= that we don't understand is kept verbatim on media.invalid
       push: 'invalid',

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,288 @@
+// https://tools.ietf.org/html/rfc4566
+// https://www.iana.org/assignments/sdp-parameters/sdp-parameters.xhtml
+
+export function write(description: SessionDescription): string;
+export function parse(description: string): SessionDescription;
+export function parsePayloads(payloads: string): number[];
+export function parseRemoteCandidates(candidates: string): Array<{
+    component: number;
+    ip: string;
+    port: number;
+}>;
+export function parseSimulcastStreamList(streams: string): Array<
+    Array<{
+        scid: number | string;
+        paused: boolean;
+    }>
+>;
+export interface ParamMap {
+    [paramName: string]: number | string;
+}
+export function parseParams(params: string): ParamMap;
+export function parseImageAttributes(params: string): ParamMap[];
+
+export interface MediaDescription extends SharedDescriptionFields, MediaAttributes {}
+
+/**
+ * Descriptor fields that exist only at the session level (before an m= block).
+ *
+ * See the SDP grammar for more details: https://tools.ietf.org/html/rfc4566#section-9
+ */
+export interface SessionDescription extends SharedDescriptionFields, SessionAttributes {
+    version?: number | undefined;
+    // o=
+    origin?: {
+        username: string;
+        sessionId: string | number;
+        sessionVersion: number;
+        netType: string;
+        ipVer: number;
+        address: string;
+    } | undefined;
+    // s=
+    name?: string | undefined;
+    // u=
+    uri?: string | undefined;
+    // e=
+    email?: string | undefined;
+    // p=
+    phone?: string | undefined;
+    // t=0 0
+    timing?: {
+        start: number;
+        stop: number;
+    } | undefined;
+    // z=
+    timezones?: string | undefined;
+    // r=
+    repeats?: string | undefined;
+    // m=
+    media: Array<
+        {
+            type: string;
+            port: number;
+            protocol: string;
+            payloads?: string | undefined;
+        } & MediaDescription
+    >;
+}
+
+/**
+ * These attributes can exist on both the session level and the media level.
+ *
+ * https://www.iana.org/assignments/sdp-parameters/sdp-parameters.xhtml#sdp-parameters-8
+ */
+export interface SharedAttributes {
+    // a=sendrecv
+    // a=recvonly
+    // a=sendonly
+    // a=inactive
+    direction?: "sendrecv" | "recvonly" | "sendonly" | "inactive" | undefined;
+    // a=control
+    control?: string | undefined;
+    // a=extmap
+    ext?:
+        | Array<{
+            value: number;
+            direction?: string | undefined;
+            uri: string;
+            config?: string | undefined;
+        }>
+        | undefined;
+    // a=setup
+    setup?: string | undefined;
+
+    iceUfrag?: string | undefined;
+    icePwd?: string | undefined;
+    fingerprint?: {
+        type: string;
+        hash: string;
+    } | undefined;
+    // a=source-filter: incl IN IP4 239.5.2.31 10.1.15.5
+    sourceFilter?: {
+        filterMode: "excl" | "incl";
+        netType: string;
+        addressTypes: string;
+        destAddress: string;
+        srcList: string;
+    } | undefined;
+    invalid?: Array<{ value: string }> | undefined;
+}
+
+/**
+ * Attributes that only exist at the session level (before an m= block).
+ *
+ * https://www.iana.org/assignments/sdp-parameters/sdp-parameters.xhtml#sdp-parameters-7
+ */
+export interface SessionAttributes extends SharedAttributes {
+    icelite?: string | undefined;
+    // a=ice-options:google-ice
+    iceOptions?: string | undefined;
+    // a=msid-semantic: WMS Jvlam5X3SX1OP6pn20zWogvaKJz5Hjf9OnlV
+    msidSemantic?: {
+        semantic: string;
+        token: string;
+    } | undefined;
+    // a=group:BUNDLE audio video
+    groups?:
+        | Array<{
+            type: string;
+            mids: string;
+        }>
+        | undefined;
+}
+
+/**
+ * Attributes that only exist at the media level (within an m= block).
+ *
+ * https://www.iana.org/assignments/sdp-parameters/sdp-parameters.xhtml#sdp-parameters-9
+ */
+export interface MediaAttributes extends SharedAttributes {
+    rtp: Array<{
+        payload: number;
+        codec: string;
+        rate?: number | undefined;
+        encoding?: number | undefined;
+    }>;
+    rtcp?: {
+        port: number;
+        netType?: string | undefined;
+        ipVer?: number | undefined;
+        address?: string | undefined;
+    } | undefined;
+    // a=rtcp-fb:98 nack rpsi
+    rtcpFb?:
+        | Array<{
+            payload: number;
+            type: string;
+            subtype?: string | undefined;
+        }>
+        | undefined;
+    // a=rtcp-fb:98 trr-int 100
+    rtcpFbTrrInt?:
+        | Array<{
+            payload: number;
+            value: number;
+        }>
+        | undefined;
+    // a=fmtp
+    fmtp: Array<{
+        payload: number;
+        config: string;
+    }>;
+    // a=mid
+    mid?: string | undefined;
+    // a=msid
+    msid?: string | undefined;
+    ptime?: number | undefined;
+    // a=maxptime
+    maxptime?: number | undefined;
+    // a=crypto
+    crypto?: {
+        id: number;
+        suite: string;
+        config: string;
+        sessionConfig?: string | undefined;
+    } | undefined;
+    // a=candidate
+    candidates?:
+        | Array<{
+            foundation: string;
+            component: number;
+            transport: string;
+            priority: number | string;
+            ip: string;
+            port: number;
+            type: string;
+            raddr?: string | undefined;
+            rport?: number | undefined;
+            tcptype?: string | undefined;
+            generation?: number | undefined;
+            "network-id"?: number | undefined;
+            "network-cost"?: number | undefined;
+        }>
+        | undefined;
+    // a=end-of-candidates
+    endOfCandidates?: string | undefined;
+    // a=remote-candidates
+    remoteCandidates?: string | undefined;
+    // a=ssrc:
+    ssrcs?:
+        | Array<{
+            id: number | string;
+            attribute: string;
+            value?: string | undefined;
+        }>
+        | undefined;
+    // a=ssrc-group:
+    ssrcGroups?:
+        | Array<{
+            semantics: string;
+            ssrcs: string;
+        }>
+        | undefined;
+    // a=rtcp-mux
+    rtcpMux?: string | undefined;
+    // a=rtcp-rsize
+    rtcpRsize?: string | undefined;
+    // a=sctpmap
+    sctpmap?: {
+        sctpmapNumber: number | string;
+        app: string;
+        maxMessageSize: number;
+    } | undefined;
+    // a=x-google-flag
+    xGoogleFlag?: string | undefined;
+    // a=rid
+    rids?:
+        | Array<{
+            id: number | string;
+            direction: string;
+            params?: string | undefined;
+        }>
+        | undefined;
+    // a=imageattr
+    imageattrs?:
+        | Array<{
+            pt: number | string;
+            dir1: string;
+            attrs1: string;
+            dir2?: string | undefined;
+            attrs2?: string | undefined;
+        }>
+        | undefined;
+    simulcast?: {
+        dir1: string;
+        list1: string;
+        dir2?: string | undefined;
+        list2?: string | undefined;
+    } | undefined;
+    simulcast_03?: { value: string } | undefined;
+    // a=framerate
+    framerate?: number | string | undefined;
+    dcdirs?: Array<{id: number, direction: "sendrecv" | "recvonly" | "sendonly" | "inactive"}>;
+    dcmaps?: Array<{id: number, options?: string}>;
+    dcsas?: Array<{id: number, attribute: string, value?: string}>;
+}
+
+/**
+ * Descriptor fields that exist at both the session level and media level.
+ *
+ * See the SDP grammar for more details: https://tools.ietf.org/html/rfc4566#section-9
+ */
+export interface SharedDescriptionFields {
+    // i=
+    description?: string | undefined;
+    // c=IN IP4 10.47.197.26
+    connection?: {
+        version: number;
+        ip: string;
+    } | undefined;
+    // b=AS:4000
+    bandwidth?:
+        | Array<{
+            type: "TIAS" | "AS" | "CT" | "RR" | "RS";
+            limit: number | string;
+        }>
+        | undefined;
+}

--- a/test/dc.sdp
+++ b/test/dc.sdp
@@ -1,0 +1,17 @@
+v=0
+o=- 20518 0 IN IP4 203.0.113.1
+s=
+t=0 0
+c=IN IP4 203.0.113.1
+a=ice-ufrag:F7gI
+a=ice-pwd:x9cml/YzichV2+XlhiMu8g
+a=fingerprint:sha-1 42:89:c5:c6:55:9d:6e:c8:e8:83:55:2a:39:f9:b6:eb:e9:a3:a9:e7
+m=application 54059 UDP/DTLS/SCTP webrtc-datachannel
+c=IN IP4 192.168.56.1
+a=sctp-port:5000
+a=max-message-size:1000
+a=dcmap:0
+a=dcmap:1 subprotocol="msrp";ordered=true;label="msrp"
+a=dcsa:1 accept-types:text/plain
+a=dcsa:1 msrp-cema
+a=dcsa:1 sendonly

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -976,3 +976,38 @@ test('ts-refclk-sess', function *(t) {
   t.equal(sessTsRefClocks[0].clksrc, 'ntp', 'NTP Clock Source');
   t.equal(sessTsRefClocks[0].clksrcExt, '/traceable/', 'traceable Clock Source');
 });
+
+test('datachannel description', function *(t) {
+  var sdp = yield fs.readFile(__dirname + '/dc.sdp', 'utf8');
+
+  var session = parse(sdp+'');
+  t.ok(session, 'got session info');
+
+  var media = session.media;
+  t.ok(media && media.length == 1, 'got single media');
+
+  var application = media[0];
+  t.ok(application.dcdirs && application.dcdirs.length == 1, 'got dcdirs');
+  t.deepEqual(application.dcdirs[0], {
+    id: 1,
+    direction: 'sendonly'
+  }, 'dcdir');
+  t.ok(application.dcmaps && application.dcmaps.length == 2, 'got dcmaps');
+  t.deepEqual(application.dcmaps[0], {
+    id: 0
+  }, 'dcmap 0');
+  t.deepEqual(application.dcmaps[1], {
+    id: 1,
+    options: 'subprotocol="msrp";ordered=true;label="msrp"'
+  }, 'dcmap 1');
+  t.ok(application.dcsas && application.dcsas.length == 2, 'got dcsas');
+  t.deepEqual(application.dcsas[0], {
+    id: 1,
+    attribute: 'accept-types',
+    value: 'text/plain'
+  }, 'dcsa 0');
+  t.deepEqual(application.dcsas[1], {
+    id: 1,
+    attribute: 'msrp-cema',
+  }, 'dcsa 1');
+});


### PR DESCRIPTION
- Parses `dcmap` and `dcsa` attributes according to https://www.rfc-editor.org/rfc/rfc8864.
  - Info is parsed into a media's newly added `dcmaps`, `dcdirs`, and `dcsas` arrays. This follows the pattern `rtp` and `fmtp` are already making
- Copy types from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/sdp-transform
  - Because I don't want to fork DefinitelyTyped or make a dedicated @types repo for this
  - Add the datachannel types
 

